### PR TITLE
Parser / Error logic

### DIFF
--- a/includes/Config.hpp
+++ b/includes/Config.hpp
@@ -6,7 +6,7 @@
 /*   By: Axel <marvin@42.fr>                        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/13 23:13:18 by Axel              #+#    #+#             */
-/*   Updated: 2024/07/19 16:01:17 by Axel             ###   ########.fr       */
+/*   Updated: 2024/08/02 11:55:12 by Axel             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,13 +18,6 @@
 #include <vector>
 #include "../includes/Parser.hpp"
 
-typedef struct s_error
-{
-	std::string reason;
-	std::string body;
-
-} t_error;
-
 class Config
 {
     public:
@@ -35,7 +28,7 @@ class Config
 
         static std::vector<int> &getPorts(void);
         static std::map<std::string, std::string> &getResources(void);
-        static std::map<int, t_error> &getErrors(void);
+        static std::map<int, std::string> &getErrors(void);
 		static std::string getServerName(void);
 		static std::vector<Route> getRoutes(void);
 		static int getMaxBodySize(void);
@@ -54,7 +47,7 @@ class Config
 		std::vector<Route> _routes;
 
         std::map<std::string, std::string> _resources;
-        std::map<int, t_error> _errors;
+        std::map<int, std::string> _errors;
 };
 
 #endif

--- a/includes/Config.hpp
+++ b/includes/Config.hpp
@@ -6,48 +6,52 @@
 /*   By: Axel <marvin@42.fr>                        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/13 23:13:18 by Axel              #+#    #+#             */
-/*   Updated: 2024/08/02 11:55:12 by Axel             ###   ########.fr       */
+/*   Updated: 2024/08/02 13:21:10 by Axel             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef CONFIG_HPP_
 #define CONFIG_HPP_
 
+#include "../includes/Parser.hpp"
 #include <map>
 #include <string>
 #include <vector>
-#include "../includes/Parser.hpp"
 
 class Config
 {
     public:
         static Config& getInstance(void);
         static void parseFile(std::string file);
-		static void clear(void);
+        static void clear(void);
         ~Config();
 
-        static std::vector<int> &getPorts(void);
-        static std::map<std::string, std::string> &getResources(void);
-        static std::map<int, std::string> &getErrors(void);
-		static std::string getServerName(void);
-		static std::vector<Route> getRoutes(void);
-		static int getMaxBodySize(void);
+        static std::vector<int>& getPorts(void);
+        static std::map<std::string, std::string>& getResources(void);
+        static std::map<int, std::string>& getDefaultErrors(void);
+		static std::map<int, std::string>& getErrorPath(void);
+        static std::string getServerName(void);
+        static std::vector<Route> getRoutes(void);
+        static int getMaxBodySize(void);
 
-		static void setServerName(const std::string &server_name);
-		static void setPort(int port_nb);
-		static void setMaxBodySize(int max_body_size);
-		static void setRoutes(const Route &route);
+        static void setServerName(const std::string& server_name);
+        static void setPort(int port_nb);
+        static void setMaxBodySize(int max_body_size);
+        static void setRoutes(const Route& route);
+		static void setErrorPath(int error_code, const std::string &path);
+		static void setDefaultErrors(int error_code, const std::string& content);
 
     private:
         Config(void);
-		
-		std::string _server_name;
+
+        std::string _server_name;
         std::vector<int> _ports;
-		int _max_body_size;
-		std::vector<Route> _routes;
+        int _max_body_size;
+        std::vector<Route> _routes;
 
         std::map<std::string, std::string> _resources;
-        std::map<int, std::string> _errors;
+        std::map<int, std::string> _default_errors;
+        std::map<int, std::string> _error_path;
 };
 
 #endif

--- a/includes/Parser.hpp
+++ b/includes/Parser.hpp
@@ -6,7 +6,7 @@
 /*   By: achabrer <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/16 10:11:15 by achabrer          #+#    #+#             */
-/*   Updated: 2024/08/02 11:19:26 by Axel             ###   ########.fr       */
+/*   Updated: 2024/08/02 13:18:06 by Axel             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -73,9 +73,8 @@ class Parser
     private:
         std::map<std::string, TokenType> _token_definition;
         std::list<Token> _token_list;
-		std::map<int, std::string> _error_path;
 
-        std::string _readFile(const std::string& config_file);
+        static std::string _readFile(const std::string& path);
         void _tokenize(std::string& file_content);
 		void _setTokenType(Token &token);
         void _parseTokenList(void);

--- a/includes/Parser.hpp
+++ b/includes/Parser.hpp
@@ -6,7 +6,7 @@
 /*   By: achabrer <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/16 10:11:15 by achabrer          #+#    #+#             */
-/*   Updated: 2024/07/23 09:25:01 by Axel             ###   ########.fr       */
+/*   Updated: 2024/08/02 11:19:26 by Axel             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -73,6 +73,7 @@ class Parser
     private:
         std::map<std::string, TokenType> _token_definition;
         std::list<Token> _token_list;
+		std::map<int, std::string> _error_path;
 
         std::string _readFile(const std::string& config_file);
         void _tokenize(std::string& file_content);
@@ -80,14 +81,13 @@ class Parser
         void _parseTokenList(void);
 		void _matchBrackets(void) const;
 		void _checkInvalidDirective(void) const;
-		void _parseServerDirective(std::list<Token>::iterator &it) const;
+		void _parseServerDirective(std::list<Token>::iterator &it);
 		void _parseLocationDirective(std::list<Token>::iterator &it) const;
-
-		//Helper
+		void _loadErrors(void) const;
+		// Helper
 		bool _isHttpMethod(const std::string &method) const;
 		bool _isValidPort(int port, const std::vector<int> &ports) const;
-
-        // DEBUG
+        // Debug
         void _debugTokenList(void) const;
         static std::string _tokenTypeToString(TokenType type);
 };

--- a/includes/RequestHandlers.hpp
+++ b/includes/RequestHandlers.hpp
@@ -6,7 +6,7 @@
 /*   By: Axel <marvin@42.fr>                        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/20 09:41:40 by Axel              #+#    #+#             */
-/*   Updated: 2024/05/26 18:34:04 by Axel             ###   ########.fr       */
+/*   Updated: 2024/08/02 11:37:57 by Axel             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,8 +26,9 @@ class ARequestHandler
         void setNextHandler(ARequestHandler* next);
 
     protected:
-        void createErrorResponse(int error_code, Response& response) const;
-        void createOkResponse(std::string resource, Response& response) const;
+        void _createErrorResponse(int error_code, Response& response) const;
+        void _createOkResponse(std::string resource, Response& response) const;
+        std::string _getErrorReason(int error_code) const;
         virtual bool _canProcess(const Request& request) const = 0;
         virtual void processRequest(const Request& request,
                                     Response& response) const = 0;

--- a/includes/Response.hpp
+++ b/includes/Response.hpp
@@ -6,7 +6,7 @@
 /*   By: Axel <marvin@42.fr>                        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/13 14:43:01 by Axel              #+#    #+#             */
-/*   Updated: 2024/05/24 20:54:54 by Axel             ###   ########.fr       */
+/*   Updated: 2024/08/02 11:53:45 by Axel             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,8 +19,11 @@
 #define DUMMY_RESPONSE                                                         \
     "<!DOCTYPE html><html><head><title>Test "                                  \
     "Page</title></head><body><h1>Hello, World!</h1></body></html>"
+
+//Error codes
 #define BAD_REQUEST 400
 #define NOT_FOUND 404
+#define INTERNAL_ERROR 500
 
 class Response
 {

--- a/includes/Response.hpp
+++ b/includes/Response.hpp
@@ -6,7 +6,7 @@
 /*   By: Axel <marvin@42.fr>                        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/13 14:43:01 by Axel              #+#    #+#             */
-/*   Updated: 2024/08/02 11:53:45 by Axel             ###   ########.fr       */
+/*   Updated: 2024/08/02 14:28:50 by Axel             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,10 +15,6 @@
 
 #include "../includes/Request.hpp"
 #include <string>
-
-#define DUMMY_RESPONSE                                                         \
-    "<!DOCTYPE html><html><head><title>Test "                                  \
-    "Page</title></head><body><h1>Hello, World!</h1></body></html>"
 
 //Error codes
 #define BAD_REQUEST 400

--- a/resources/config/default.conf
+++ b/resources/config/default.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80 8080;
+    listen 8080 8081;
     server_name example.com;
     client_max_body_size 10;
     error_page 404 /404.html;

--- a/resources/errors/404.html
+++ b/resources/errors/404.html
@@ -7,7 +7,7 @@
 
 <body>
 	<h1>Not Found</h1>
-	<p>The requested URL /path/to/resource was not found on this server.</p>
+	<p>The requested URL was not found on this server.</p>
 </body>
 
 </html>

--- a/resources/errors/500.html
+++ b/resources/errors/500.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>500 Internal Server Error</title>
+</head>
+
+<body>
+	<p>An internal error occured</p>
+</body>
+
+</html>

--- a/sources/Config.cpp
+++ b/sources/Config.cpp
@@ -6,7 +6,7 @@
 /*   By: Axel <marvin@42.fr>                        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/13 23:17:43 by Axel              #+#    #+#             */
-/*   Updated: 2024/07/19 16:33:01 by Axel             ###   ########.fr       */
+/*   Updated: 2024/08/02 11:54:29 by Axel             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,14 +34,14 @@ void Config ::parseFile(std::string file)
     (void)file;
     /* load errors provided into the conf file*/
     /* if not provided load the rest or the errors supported by our server*/
-    getInstance()._errors[NOT_FOUND] =
-        (t_error){"Not Found", "<h1>404 Not Found</h1>"};
-    getInstance()._errors[500] = (t_error){
-        "Internal Server Error", "<h1>500 Internal Server Error</h1>"};
-    getInstance()._errors[BAD_REQUEST] =
-        (t_error){"Bad Request",
-                  "<h1>400 Bad Request</h1><p>The server could not understand "
-                  "the request due to invalid syntax.</p>"};
+
+    getInstance()._errors.insert(
+        std::make_pair(NOT_FOUND, "<h1>404 Not Found</h1>"));
+    getInstance()._errors.insert(std::make_pair(
+        BAD_REQUEST, "<h1>400 Bad Request</h1><p>The server could not "
+                     "understand the request due to invalid syntax.</p>"));
+    getInstance()._errors.insert(
+        std::make_pair(INTERNAL_ERROR, "<h1>500 Internal Server Error</h1>"));
 
     getInstance()._resources.insert(std::make_pair("/", DUMMY_RESPONSE));
 
@@ -76,14 +76,14 @@ void Config ::parseFile(std::string file)
 
 void Config ::clear(void)
 {
-    Config &instance = getInstance();
+    Config& instance = getInstance();
 
     instance._ports.clear();
     instance._server_name.clear();
     instance._resources.clear();
     instance._errors.clear();
-	instance._routes.clear();
-	instance._max_body_size = 100;
+    instance._routes.clear();
+    instance._max_body_size = 100;
 }
 
 // _/=\_/=\_/=\_/=\_/=\_/=\_/=\_/ GETTERS \_/=\_/=\_/=\_/=\_/=\_/=\_/=\_
@@ -96,7 +96,7 @@ std::map<std::string, std::string>& Config::getResources(void)
     return (getInstance()._resources);
 }
 
-std::map<int, t_error>& Config::getErrors(void)
+std::map<int, std::string>& Config::getErrors(void)
 {
     return (getInstance()._errors);
 }
@@ -104,7 +104,6 @@ std::map<int, t_error>& Config::getErrors(void)
 std::vector<Route> Config::getRoutes(void) { return (getInstance()._routes); }
 
 int Config ::getMaxBodySize(void) { return (getInstance()._max_body_size); }
-
 
 // _/=\_/=\_/=\_/=\_/=\_/=\_/=\_/ SETTERS \_/=\_/=\_/=\_/=\_/=\_/=\_/=\_
 void Config::setServerName(const std::string& server_name)

--- a/sources/Config.cpp
+++ b/sources/Config.cpp
@@ -6,12 +6,11 @@
 /*   By: Axel <marvin@42.fr>                        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/13 23:17:43 by Axel              #+#    #+#             */
-/*   Updated: 2024/08/02 13:25:25 by Axel             ###   ########.fr       */
+/*   Updated: 2024/08/02 14:29:42 by Axel             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/Config.hpp"
-#include "../includes/Response.hpp"
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -29,29 +28,27 @@ Config& Config::getInstance(void)
 
 Config ::~Config(void) {}
 
+//Dummy implementation, should be removed as soon as possible
 void Config ::parseFile(std::string file)
 {
     (void)file;
-    /* load errors provided into the conf file*/
-    /* if not provided load the rest or the errors supported by our server*/
-    //
-    // getInstance()._default_errors.insert(
-    //     std::make_pair(NOT_FOUND, "<h1>404 Not Found</h1>"));
-    // getInstance()._default_errors.insert(std::make_pair(
-    //     BAD_REQUEST, "<h1>400 Bad Request</h1><p>The server could not "
-    //                  "understand the request due to invalid syntax.</p>"));
-    // getInstance()._default_errors.insert(
-    //     std::make_pair(INTERNAL_ERROR, "<h1>500 Internal Server Error</h1>"));
-    //
-    getInstance()._resources.insert(std::make_pair("/", DUMMY_RESPONSE));
 
-    /* We basically need to do the following with all our resources*/
     std::ifstream ifs("resources/form.html");
     if (!ifs)
         throw std::runtime_error("Couldn't open the file");
     std::stringstream buff;
     buff << ifs.rdbuf();
     getInstance()._resources.insert(std::make_pair("/form", buff.str()));
+
+    ifs.close();
+    ifs.clear();
+    ifs.open("resources/index.html");
+    if (!ifs)
+        throw std::runtime_error("Couldn't open the file");
+    buff.clear();
+    buff.str("");
+    buff << ifs.rdbuf();
+    getInstance()._resources.insert(std::make_pair("/", buff.str()));
 
     ifs.close();
     ifs.clear();

--- a/sources/Config.cpp
+++ b/sources/Config.cpp
@@ -6,7 +6,7 @@
 /*   By: Axel <marvin@42.fr>                        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/13 23:17:43 by Axel              #+#    #+#             */
-/*   Updated: 2024/08/02 11:54:29 by Axel             ###   ########.fr       */
+/*   Updated: 2024/08/02 13:25:25 by Axel             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,15 +34,15 @@ void Config ::parseFile(std::string file)
     (void)file;
     /* load errors provided into the conf file*/
     /* if not provided load the rest or the errors supported by our server*/
-
-    getInstance()._errors.insert(
-        std::make_pair(NOT_FOUND, "<h1>404 Not Found</h1>"));
-    getInstance()._errors.insert(std::make_pair(
-        BAD_REQUEST, "<h1>400 Bad Request</h1><p>The server could not "
-                     "understand the request due to invalid syntax.</p>"));
-    getInstance()._errors.insert(
-        std::make_pair(INTERNAL_ERROR, "<h1>500 Internal Server Error</h1>"));
-
+    //
+    // getInstance()._default_errors.insert(
+    //     std::make_pair(NOT_FOUND, "<h1>404 Not Found</h1>"));
+    // getInstance()._default_errors.insert(std::make_pair(
+    //     BAD_REQUEST, "<h1>400 Bad Request</h1><p>The server could not "
+    //                  "understand the request due to invalid syntax.</p>"));
+    // getInstance()._default_errors.insert(
+    //     std::make_pair(INTERNAL_ERROR, "<h1>500 Internal Server Error</h1>"));
+    //
     getInstance()._resources.insert(std::make_pair("/", DUMMY_RESPONSE));
 
     /* We basically need to do the following with all our resources*/
@@ -81,7 +81,7 @@ void Config ::clear(void)
     instance._ports.clear();
     instance._server_name.clear();
     instance._resources.clear();
-    instance._errors.clear();
+    instance._default_errors.clear();
     instance._routes.clear();
     instance._max_body_size = 100;
 }
@@ -96,9 +96,14 @@ std::map<std::string, std::string>& Config::getResources(void)
     return (getInstance()._resources);
 }
 
-std::map<int, std::string>& Config::getErrors(void)
+std::map<int, std::string>& Config::getDefaultErrors(void)
 {
-    return (getInstance()._errors);
+    return (getInstance()._default_errors);
+}
+
+std::map<int, std::string>& Config::getErrorPath(void)
+{
+    return (getInstance()._error_path);
 }
 
 std::vector<Route> Config::getRoutes(void) { return (getInstance()._routes); }
@@ -121,4 +126,14 @@ void Config ::setMaxBodySize(int max_body_size)
 void Config ::setRoutes(const Route& route)
 {
     getInstance()._routes.push_back(route);
+}
+
+void Config::setDefaultErrors(int error_code, const std::string& content)
+{
+    getInstance()._default_errors.insert(std::make_pair(error_code, content));
+}
+
+void Config::setErrorPath(int error_code, const std::string& path)
+{
+    getInstance()._error_path.insert(std::make_pair(error_code, path));
 }

--- a/sources/Parser.cpp
+++ b/sources/Parser.cpp
@@ -6,12 +6,13 @@
 /*   By: Axel <marvin@42.fr>                        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/18 08:46:08 by Axel              #+#    #+#             */
-/*   Updated: 2024/08/02 11:21:46 by Axel             ###   ########.fr       */
+/*   Updated: 2024/08/02 13:33:26 by Axel             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/Parser.hpp"
 #include "../includes/Config.hpp"
+#include "../includes/utils.hpp"
 #include <cstddef>
 #include <cstdlib>
 #include <fstream>
@@ -47,16 +48,16 @@ void Parser ::parse(const std::string& config_file)
     _loadErrors();
 }
 
-std::string Parser ::_readFile(const std::string& config_file)
+std::string Parser ::_readFile(const std::string& path)
 {
     std::ifstream ifs;
     std::string line;
     std::stringstream file_content;
 
-    ifs.open(config_file.c_str());
+    ifs.open(path.c_str());
     if (!ifs.is_open())
-        throw std::runtime_error(
-            "Couldn't open the config file: file doesn't exist");
+        throw std::runtime_error("Couldn't open the file " + path +
+                                 ": file doesn't exist");
     while (ifs.good())
     {
         std::getline(ifs, line);
@@ -214,7 +215,7 @@ void Parser ::_parseServerDirective(std::list<Token>::iterator& it)
         {
             int error_code = std::atoi((it++)->content.c_str());
             std::string path_to_html = (it++)->content;
-            _error_path.insert(std::make_pair(error_code, path_to_html));
+            Config::setErrorPath(error_code, path_to_html);
         }
         else if (it->content == "listen")
         {
@@ -301,9 +302,21 @@ bool Parser::_isValidPort(int port_nb, const std::vector<int>& ports) const
 }
 
 /**
- * @brief load error pages into the config.
+ * @brief load default error pages into the config.
  */
-void Parser::_loadErrors(void) const {}
+void Parser::_loadErrors(void) const
+{
+    int tmp[] = {400, 404, 500};
+    std::vector<int> error_codes(tmp, tmp + sizeof(tmp) / sizeof(int));
+
+    for (size_t i = 0; i < error_codes.size(); i++)
+    {
+        std::string path =
+            "./resources/errors/" + toString(error_codes[i]) + ".html";
+        std::string content = _readFile(path);
+		 Config::setDefaultErrors(error_codes[i], content);
+    }
+}
 
 // =============================================================================
 //                               Debug
@@ -352,7 +365,9 @@ std::string Parser ::_tokenTypeToString(TokenType type)
     }
 }
 
-// _/=\_/=\_/=\_/=\_/=\_/=\_/=\_/ EXCEPTION \_/=\_/=\_/=\_/=\_/=\_/=\_/=\_
+// =============================================================================
+//                               Exception
+// =============================================================================
 Parser ::SynthaxException::SynthaxException(const Token& token,
                                             const std::string& reason)
     : _token(token), _reason(reason)

--- a/sources/RequestHandlers.cpp
+++ b/sources/RequestHandlers.cpp
@@ -6,7 +6,7 @@
 /*   By: Axel <marvin@42.fr>                        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/20 09:47:14 by Axel              #+#    #+#             */
-/*   Updated: 2024/08/02 12:00:55 by Axel             ###   ########.fr       */
+/*   Updated: 2024/08/02 12:22:27 by Axel             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,7 +64,7 @@ void ARequestHandler ::_createErrorResponse(int error_code,
     std::string headers;
 
     // codes we want to handle have to exist
-    it = Config::getErrors().find(error_code);
+    it = Config::getDefaultErrors().find(error_code);
 
     response.setBody(it->second);
     headers =

--- a/sources/Server.cpp
+++ b/sources/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: Axel <marvin@42.fr>                        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/12 10:05:43 by Axel              #+#    #+#             */
-/*   Updated: 2024/08/02 11:55:30 by Axel             ###   ########.fr       */
+/*   Updated: 2024/08/02 13:59:57 by Axel             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,7 +39,7 @@ Server ::Server(std::string config_file)
 	Config::parseFile(config_file);
 	(void)config_file;
     Log::setLogLevel(DEBUG);
-    // Log::clearScreen();
+    Log::clearScreen();
 }
 
 Server ::~Server()

--- a/sources/Server.cpp
+++ b/sources/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: Axel <marvin@42.fr>                        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/12 10:05:43 by Axel              #+#    #+#             */
-/*   Updated: 2024/07/19 15:35:45 by Axel             ###   ########.fr       */
+/*   Updated: 2024/08/02 11:55:30 by Axel             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,6 +36,7 @@ Server ::Server(std::string config_file)
 	Parser parser;
 
 	parser.parse(config_file);
+	Config::parseFile(config_file);
 	(void)config_file;
     Log::setLogLevel(DEBUG);
     // Log::clearScreen();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 3.8)
 set(This webserv_test)
 
 set(Sources
-	# request_test.cpp
-	# Response_test.cpp
+	request_test.cpp
+	Response_test.cpp
 	Parser_test.cpp
     test.cpp)
 

--- a/test/Parser_test.cpp
+++ b/test/Parser_test.cpp
@@ -6,7 +6,7 @@
 /*   By: Axel <marvin@42.fr>                        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/18 09:20:15 by Axel              #+#    #+#             */
-/*   Updated: 2024/07/19 16:41:10 by Axel             ###   ########.fr       */
+/*   Updated: 2024/08/02 13:31:31 by Axel             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ TEST(Parser, simple_config)
 
     parser.parse("resources/config/default.conf");
     ASSERT_EQ(Config::getPorts()[0], 80);
-    ASSERT_EQ(Config::getPorts().size(), 1);
+    ASSERT_EQ(Config::getPorts().size(), 2);
     ASSERT_EQ(Config::getServerName(), "example.com");
     ASSERT_EQ(Config::getMaxBodySize(), 10);
     Config::clear();
@@ -35,11 +35,21 @@ TEST(Parser, Routes)
     parser.parse("resources/config/default.conf");
     std::vector<Route> routes = Config::getRoutes();
     ASSERT_EQ(routes.size(), 1);
-	ASSERT_EQ(routes[0].methods.size(), 2);
-	ASSERT_EQ(routes[0].methods[0], "GET");
-	ASSERT_EQ(routes[0].methods[1], "POST");
-	ASSERT_EQ(routes[0].root, "./resources");
-	ASSERT_EQ(routes[0].index, "index.html");
-	ASSERT_EQ(routes[0].upload_store, "./uploads");
-	ASSERT_EQ(routes[0].cgi_extension, ".php");
+    ASSERT_EQ(routes[0].methods.size(), 2);
+    ASSERT_EQ(routes[0].methods[0], "GET");
+    ASSERT_EQ(routes[0].methods[1], "POST");
+    ASSERT_EQ(routes[0].root, "./resources");
+    ASSERT_EQ(routes[0].index, "index.html");
+    ASSERT_EQ(routes[0].upload_store, "./uploads");
+    ASSERT_EQ(routes[0].cgi_extension, ".php");
+    Config::clear();
+}
+
+TEST(Parser, default_errors)
+{
+    Parser parser;
+
+    parser.parse("resources/config/default.conf");
+	ASSERT_EQ(3, Config::getDefaultErrors().size());
+	Config::clear();
 }


### PR DESCRIPTION
- t_error removed, the default errors are now simply stored into a map<err_code, html_template>
- added _error_path in the config: map error code with a path. before serving error pages we will need to check first those path